### PR TITLE
PDA-27: Add jest-junit dependency

### DIFF
--- a/widgets/README.md
+++ b/widgets/README.md
@@ -1,5 +1,7 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+[![Build Status](https://jenkins.entandocloud.com/buildStatus/icon?job=pda-widgets-master)](https://jenkins.entandocloud.com/job/pda-widgets-master/)
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/widgets/package-lock.json
+++ b/widgets/package-lock.json
@@ -9075,6 +9075,19 @@
         "throat": "^4.0.0"
       }
     },
+    "jest-junit": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-10.0.0.tgz",
+      "integrity": "sha512-dbOVRyxHprdSpwSAR9/YshLwmnwf+RSl5hf0kCGlhAcEeZY9aRqo4oNmaT0tLC16Zy9D0zekDjWkjHGjXlglaQ==",
+      "dev": true,
+      "requires": {
+        "jest-validate": "^24.9.0",
+        "mkdirp": "^0.5.1",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      }
+    },
     "jest-leak-detector": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
@@ -16379,6 +16392,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -113,6 +113,7 @@
     "i18next-scanner": "^2.10.3",
     "jest-dom": "^4.0.0",
     "jest-fetch-mock": "^2.1.2",
+    "jest-junit": "^10.0.0",
     "lint-staged": "^9.2.5",
     "patternfly": "^3.59.4",
     "patternfly-react": "^1.19.1",


### PR DESCRIPTION
Adding jest-junit dependency, so we will be able to publish test results to jenkins and also to the status check on Github.
Now the build command on Jenkins for PR builds become:
```
npm test -- --coverage --watchAll=false --reporters=default --reporters=jest-junit
```